### PR TITLE
uses lowercase names in mapping for efficient cache purposes

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -34,7 +34,7 @@ app.post('/professor', async (req, res) => {
       .send({ err: 'name of professor needs to be specified' });
   }
 
-  const name: string = req.body.name;
+  const name: string = req.body.name.toLowerCase();
   let data: ProfessorPage | null;
 
   // RMP name provided

--- a/api/server.ts
+++ b/api/server.ts
@@ -34,14 +34,14 @@ app.post('/professor', async (req, res) => {
       .send({ err: 'name of professor needs to be specified' });
   }
 
-  const name: string = req.body.name.toLowerCase();
+  const name: string = req.body.name;
   let data: ProfessorPage | null;
 
   // RMP name provided
-  if (!(name in cachedProfData)) {
+  if (!(name.toLowerCase() in cachedProfData)) {
     const result = await checkProfName(name); // row data of mysql, will return the name if exists
     if (result.length > 0) {
-      cachedProfData[name] = await getProfessorByName(name); // maps data for every new professor
+      cachedProfData[name.toLowerCase()] = await getProfessorByName(name); // maps data for every new professor
       console.log('NEW PROFESSOR ADDED, ', name);
     } else {
       return res.status(400).send('professor not found in mapping');
@@ -49,7 +49,7 @@ app.post('/professor', async (req, res) => {
   }
 
   // eslint-disable-next-line prefer-const
-  data = cachedProfData[name];
+  data = cachedProfData[name.toLowerCase()];
 
   if (!data) {
     res.status(400).send('name of professor not in RMP');

--- a/api/server.ts
+++ b/api/server.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import express from 'express';
 import { ProfessorPage } from '../scraper/graphql/interface';
 import { getProfessorByName } from '../scraper/scraper';
-import { initializeMySQL } from './sql';
+import { initializeMySQL, checkProfName } from './sql';
 
 const app = express();
 app.use(express.json());
@@ -42,13 +42,11 @@ app.post('/professor', async (req, res) => {
   let data: ProfessorPage | null;
 
   // RMP name provided
-  if ('exact' in req.body) {
+  const result = await checkProfName(name); // row data of mysql, will return the name if exists
+  if (result.length > 0) {
     data = await getProfessorByName(name);
   } else {
-    if (!(name in tempMapping)) {
-      return res.status(400).send('professor not found in mapping');
-    }
-    data = await getProfessorByName(tempMapping[name]);
+    return res.status(400).send('professor not found in mapping');
   }
 
   if (!data) {

--- a/api/server.ts
+++ b/api/server.ts
@@ -17,13 +17,9 @@ function checkEmpty(content: object, res: any): boolean {
   return false;
 }
 
-/* eslint-disable @typescript-eslint/naming-convention */
-const tempMapping: { [key: string]: string } = {
-  'Hao Ji': 'Hao Ji',
-  'Ben Steichen': 'Ben Steichen',
-};
-/* eslint-enable @typescript-eslint/naming-convention */
+const cachedProfData: { [key: string]: ProfessorPage | null } = {};
 
+/* eslint-enable @typescript-eslint/naming-convention */
 app.post('/professor', async (req, res) => {
   // API returns single professor data or null if doesn't exist
   // I'm using a single object, but Ideally this should be a nested object? this is the format that I'll just stick with
@@ -42,12 +38,18 @@ app.post('/professor', async (req, res) => {
   let data: ProfessorPage | null;
 
   // RMP name provided
-  const result = await checkProfName(name); // row data of mysql, will return the name if exists
-  if (result.length > 0) {
-    data = await getProfessorByName(name);
-  } else {
-    return res.status(400).send('professor not found in mapping');
+  if (!(name in cachedProfData)) {
+    const result = await checkProfName(name); // row data of mysql, will return the name if exists
+    if (result.length > 0) {
+      cachedProfData[name] = await getProfessorByName(name); // maps data for every new professor
+      console.log('NEW PROFESSOR ADDED, ', name);
+    } else {
+      return res.status(400).send('professor not found in mapping');
+    }
   }
+
+  // eslint-disable-next-line prefer-const
+  data = cachedProfData[name];
 
   if (!data) {
     res.status(400).send('name of professor not in RMP');

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -202,6 +202,4 @@ export async function initializeMySQL(): Promise<void> {
   // addProf(sampleProf);
   // const result = await profSearch('Poppy Gloria');
   // console.log(result);
-  addProfName('Ben Steichen');
-  addProfName('Thanh Nguyen');
 }

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -43,7 +43,6 @@ async function profSearch(broncoDirectName: string): Promise<void> {
   return result;
 }
 
-
 /**
  * Adds a professor to the profDB table in SQL database
  * @param {string} broncoDirectName name to be added

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -35,7 +35,7 @@ async function execute(cmd: string, placeholder?: string[]): Promise<any> {
  */
 async function profSearch(broncoDirectName: string): Promise<void> {
   const result = await execute(
-    'SELECT * FROM `professorDB` WHERE `broncoDirectName` = ?',
+    'SELECT * FROM `rateMyProfessorDB` WHERE `broncoDirectName` = ?',
     [broncoDirectName]
   );
   return result;
@@ -53,7 +53,8 @@ function addProf({
   profDifficulty,
   takeClassAgain,
 }: Professor): void {
-  void execute('INSERT INTO professorDB VALUES (?, ?, ?, ?, ?, ?)', [
+  void execute('INSERT INTO rateMyProfessorDB VALUES (?, ?, ?, ?, ?, ?, ?)', [
+    '',
     broncoDirectName,
     rmpName,
     rmpURL,
@@ -65,10 +66,25 @@ function addProf({
 
 /**
  * Adds a professor to the profDB table in SQL database
- * @param {Professor} professor See professor interface (/api/Professor.d.ts)
+ * @param {string} broncoDirectName name to be added
  */
-function addProfName({ broncoDirectName }: Professor): void {
-  void execute('INSERT INTO professorDB VALUES (?)', [broncoDirectName]);
+export function addProfName(broncoDirectName: string): void {
+  void execute('INSERT INTO professorDB VALUES (?, ?)', ['', broncoDirectName]);
+}
+
+/**
+ * Checks if a professor exists in the database (meaning they are a valid professor)
+ * @param {string} broncoDirectName name to be checked
+ * @return {Promise<object[]>} array of row data in db
+ */
+export async function checkProfName(
+  broncoDirectName: string
+): Promise<object[]> {
+  const result = await execute(
+    'SELECT * FROM `professorDB` WHERE `broncoDirectName` = ?',
+    [broncoDirectName]
+  );
+  return result;
 }
 
 /**
@@ -172,4 +188,20 @@ export async function initializeMySQL(): Promise<void> {
     userID int NOT NULL PRIMARY KEY AUTO_INCREMENT,
     userEmail varchar(255)
   )`);
+
+  // const sampleProf: Professor = {
+  //   broncoDirectName: 'Poppy Gloria',
+  //   rmpName: 'Poppy Gloria',
+  //   rmpURL: 'ratemyprofessor.com/PoppyGloria',
+  //   profRating: 10.0,
+  //   profDifficulty: 2.1,
+  //   takeClassAgain: 1.0,
+  // };
+
+  // console.log('yeet');
+  // addProf(sampleProf);
+  // const result = await profSearch('Poppy Gloria');
+  // console.log(result);
+  addProfName('Ben Steichen');
+  addProfName('Thanh Nguyen');
 }

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -34,6 +34,7 @@ async function execute(cmd: string, placeholder?: string[]): Promise<any> {
  * @return {Promise<void>} Array of JSON values.
  * Value can be extracted by awaiting function call within an async function
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function profSearch(broncoDirectName: string): Promise<void> {
   const result = await execute(
     'SELECT * FROM `rateMyProfessorDB` WHERE `broncoDirectName` = ?',
@@ -42,28 +43,6 @@ async function profSearch(broncoDirectName: string): Promise<void> {
   return result;
 }
 
-/**
- * Adds a professor to the SQL database
- * @param {Professor} professor See professor interface (/api/Professor.d.ts)
- */
-function addProf({
-  broncoDirectName,
-  rmpName,
-  rmpURL,
-  profRating,
-  profDifficulty,
-  takeClassAgain,
-}: Professor): void {
-  void execute('INSERT INTO rateMyProfessorDB VALUES (?, ?, ?, ?, ?, ?, ?)', [
-    '',
-    broncoDirectName,
-    rmpName,
-    rmpURL,
-    profRating.toFixed(2),
-    profDifficulty.toFixed(2),
-    takeClassAgain.toFixed(2),
-  ]);
-}
 
 /**
  * Adds a professor to the profDB table in SQL database
@@ -94,6 +73,7 @@ export async function checkProfName(
  * Updates existing professor in the SQL database
  * @param {Professor} newProfessor See professor interface (/api/Professor.d.ts)
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function updateProf({
   broncoDirectName,
   rmpName,

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -64,6 +64,14 @@ function addProf({
 }
 
 /**
+ * Adds a professor to the profDB table in SQL database
+ * @param {Professor} professor See professor interface (/api/Professor.d.ts)
+ */
+function addProfName({ broncoDirectName }: Professor): void {
+  void execute('INSERT INTO professorDB VALUES (?)', [broncoDirectName]);
+}
+
+/**
  * Updates existing professor in the SQL database
  * @param {Professor} newProfessor See professor interface (/api/Professor.d.ts)
  */

--- a/scraper/professors/populate.ts
+++ b/scraper/professors/populate.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 // @ts-nocheck
-// import { addProf } from '../../api/sql';
+import { addProfName } from '../../api/sql';
 
 const fs = require('fs');
 const readline = require('readline');
@@ -26,7 +26,7 @@ readline
     );
 
     // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-    // addProf(name[1] + ' ' + name[0])  // addProf function not yet updated to new schema
+    addProfName(name[1] + ' ' + name[0]);
 
     // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     console.log(name[1] + ' ' + name[0]);

--- a/scraper/professors/populate.ts
+++ b/scraper/professors/populate.ts
@@ -1,13 +1,33 @@
-var fs = require('fs');
-var readline = require('readline');
+/* eslint-disable @typescript-eslint/no-var-requires */
+// @ts-nocheck
+// import { addProf } from '../../api/sql';
+
+const fs = require('fs');
+const readline = require('readline');
 
 readline
   .createInterface({
     input: fs.createReadStream('./scraper/professors/professors.txt'),
   })
+
+  /* 
+  Manual editing is required
+  Some professors have full middle names or middle initials which is impossible to differentiate
+  so some names will be very inaccurate and will need to be edited in the database
+  */
+
   .on('line', (line) => {
-    if (line.includes('//')) return; //lines in professor.txt marked with a '//' will be skipped
-    var name = line.split(/[\s,]/);
-    name = name.filter((a) => a.length > 1 && !a.match(/[.(]/));
-    console.log(name);
+    if (line.includes('//')) return; // lines in professor.txt marked with a '//' will be skipped
+    const titles = ['Mr', 'Ms', 'Mrs', 'PhD', 'II', 'III', 'IV'];
+    const specialChars = /[.(]/;
+    let name = line.split(/[\s,]/);
+    name = name.filter(
+      (a) => !titles.includes(a) && a.length > 1 && !a.match(specialChars)
+    );
+
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+    // addProf(name[1] + ' ' + name[0])  // addProf function not yet updated to new schema
+
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+    console.log(name[1] + ' ' + name[0]);
   });

--- a/scraper/professors/populate.ts
+++ b/scraper/professors/populate.ts
@@ -1,5 +1,7 @@
 export async function readFile(): Promise<string[]> {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const readline = require('readline');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const fs = require('fs');
   const nameArray = [];
   const readStream = fs.createReadStream('./scraper/professors/professors.txt');

--- a/scraper/professors/populate.ts
+++ b/scraper/professors/populate.ts
@@ -1,0 +1,13 @@
+var fs = require('fs');
+var readline = require('readline');
+
+readline
+  .createInterface({
+    input: fs.createReadStream('./scraper/professors/professors.txt'),
+  })
+  .on('line', (line) => {
+    if (line.includes('//')) return; //lines in professor.txt marked with a '//' will be skipped
+    var name = line.split(/[\s,]/);
+    name = name.filter((a) => a.length > 1 && !a.match(/[.(]/));
+    console.log(name);
+  });

--- a/scraper/professors/populate.ts
+++ b/scraper/professors/populate.ts
@@ -1,14 +1,11 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-// @ts-nocheck
-import { addProfName } from '../../api/sql';
-
-const fs = require('fs');
-const readline = require('readline');
-
-readline
-  .createInterface({
-    input: fs.createReadStream('./scraper/professors/professors.txt'),
-  })
+export async function readFile(): Promise<string[]> {
+  const readline = require('readline');
+  const fs = require('fs');
+  const nameArray = [];
+  const readStream = fs.createReadStream('./scraper/professors/professors.txt');
+  const rl = readline.createInterface({
+    input: readStream,
+  });
 
   /* 
   Manual editing is required
@@ -16,18 +13,19 @@ readline
   so some names will be very inaccurate and will need to be edited in the database
   */
 
-  .on('line', (line) => {
-    if (line.includes('//')) return; // lines in professor.txt marked with a '//' will be skipped
+  for await (const line of rl) {
+    if (line.includes('//')) continue; // lines in professor.txt marked with a '//' will be skipped
     const titles = ['Mr', 'Ms', 'Mrs', 'PhD', 'II', 'III', 'IV'];
     const specialChars = /[.(]/;
     let name = line.split(/[\s,]/);
     name = name.filter(
-      (a) => !titles.includes(a) && a.length > 1 && !a.match(specialChars)
+      (a: string) =>
+        !titles.includes(a) && a.length > 1 && !a.match(specialChars)
     );
 
     // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-    addProfName(name[1] + ' ' + name[0]);
-
-    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-    console.log(name[1] + ' ' + name[0]);
-  });
+    nameArray.push(name[1] + ' ' + name[0]);
+  }
+  console.log(nameArray);
+  return nameArray;
+}


### PR DESCRIPTION
Case sensitivity is properly avoided by mapping lowercased professor names rather than the actual query (which previously resulted in several variants of the same professor).