### PR TITLE
Auto rebooting MySQL Connection

### DIFF
--- a/api/sql.ts
+++ b/api/sql.ts
@@ -107,6 +107,21 @@ async function checkDatabaseExist(): Promise<boolean> {
   return resultAmount > 0;
 }
 
+// checks if there is an active SQL connection
+export async function checkSQLConnection(): Promise<boolean> {
+  // makes sure connection has a ping command
+  if (!connection?.ping) {
+    return false;
+  }
+
+  try {
+    connection.ping();
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
 /**
  * Initializes mySQL in the backend by creating a connection to the mySQL server. See comments within the function for download instructions on mySQL by ctrl (windows) / option (mac) clicking the function name.
  */

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.2",
     "express": "^4.18.1",
+    "graphql": "^16.6.0",
     "graphql-request": "^5.0.0",
     "mysql2": "^2.3.3",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
As of right now, any calls to our API is done via 1 connection to the MySQL. As such, if that connection disconnects (which it automatically does, around 8 hours of non-use), it is possible to crash the backend server if someone tries to make a call to the server while there isn't a connection.

- These changes fixes that problem by adding a middleware to the POST server.ts calls, which basically checks if there exists a MySQL connection before actually going through with the request. If the connection is offline, it will automatically boot it back up before making the call, which prevents the potential for crashes in this scenario.
- I also updated package.json to include graphql as a dependency so the backend server can install it (graphql is required to get RMP data)

This highlights **a standard we need to follow**: always try/catch any potential for errors so the backend server doesn't die. Thanks for coming to my ted talk