### PR TITLE
Backend Prof Caching Improvements

### DIFF
--- a/api/Professor.d.ts
+++ b/api/Professor.d.ts
@@ -9,3 +9,11 @@ export interface Professor {
   id: string;
   legacyId: number;
 }
+
+export interface ProfessorUpdate {
+  profName: string;
+  avgDifficulty: number;
+  avgRating: number;
+  numRatings: number;
+  wouldTakeAgainPercent: number;
+}

--- a/api/Professor.d.ts
+++ b/api/Professor.d.ts
@@ -1,8 +1,11 @@
 export interface Professor {
-  broncoDirectName: string;
-  rmpName: string;
-  rmpURL: string;
-  profRating: number;
-  profDifficulty: number;
-  takeClassAgain: number;
+  profName: string;
+  firstName: string;
+  lastName: string;
+  avgDifficulty: number;
+  avgRating: number;
+  numRatings: number;
+  wouldTakeAgainPercent: number;
+  id: string;
+  legacyId: number;
 }

--- a/api/server.ts
+++ b/api/server.ts
@@ -28,7 +28,6 @@ const checkConnection = async (
     console.log('MySQL server not connected. Starting server...');
     try {
       await initializeMySQL();
-      console.log('MySQL server started.');
     } catch (err) {
       console.error('Error starting MySQL server: ', err);
       return res.status(500).send('Error starting MySQL server.');
@@ -75,7 +74,6 @@ app.post('/professor', async (req, res) => {
       if ((await checkProfName(name)).length > 0) {
         await addProf(name);
         data = await profSearch(name); // re-query data after adding info
-        console.log(data);
         console.log(
           `[SUCCESS] Professor ${name} has been added to the database.`
         );

--- a/api/server.ts
+++ b/api/server.ts
@@ -69,7 +69,7 @@ app.post('/professor', async (req, res) => {
   try {
     // Check if prof data already exists
     const result = await profSearch(name);
-    if (Object.keys(result).length === 0) {
+    if (result && Object.keys(result).length === 0) {
       /* No data found in db based on 'name' */
       // Check if prof name actually exists in cpp
       if ((await checkProfName(name)).length > 0) {

--- a/api/server.ts
+++ b/api/server.ts
@@ -69,12 +69,13 @@ app.post('/professor', async (req, res) => {
   try {
     // Check if prof data already exists
     const result = await profSearch(name);
-    if (result && Object.keys(result).length === 0) {
+    if (!result || Object.keys(result).length === 0) {
       /* No data found in db based on 'name' */
       // Check if prof name actually exists in cpp
       if ((await checkProfName(name)).length > 0) {
         await addProf(name);
         data = await profSearch(name); // re-query data after adding info
+        console.log(data);
         console.log(
           `[SUCCESS] Professor ${name} has been added to the database.`
         );

--- a/api/server.ts
+++ b/api/server.ts
@@ -74,9 +74,6 @@ app.post('/professor', async (req, res) => {
       if ((await checkProfName(name)).length > 0) {
         await addProf(name);
         data = await profSearch(name); // re-query data after adding info
-        console.log(
-          `[SUCCESS] Professor ${name} has been added to the database.`
-        );
       } else {
         return res.status(400).send('professor not found in mapping');
       }
@@ -91,7 +88,6 @@ app.post('/professor', async (req, res) => {
         wouldTakeAgainPercent: newData?.wouldTakeAgainPercent ?? -1,
       });
       data = await profSearch(name); // re-query data after updating info
-      console.log(`[SUCCESS] Professor ${name} has been updated.`);
     } else {
       /* Data exists and is younger than 3mo */
       data = result;

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -34,10 +34,10 @@ async function execute(cmd: string, placeholder?: string[]): Promise<any> {
  * @param {Professor} newProfessor See professor interface (/api/Professor.d.ts)
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function addProf(broncoDirectName: string): Promise<void> {
+export async function addProf(broncoDirectName: string): Promise<void> {
   try {
     const data = await getProfessorByName(broncoDirectName.toLowerCase());
-    if (data) {
+    if (data && Object.keys(data).length > 0) {
       await addProfGraphQL({
         profName: broncoDirectName.toLowerCase(),
         firstName: data?.firstName,
@@ -50,7 +50,9 @@ async function addProf(broncoDirectName: string): Promise<void> {
         legacyId: data?.legacyId,
       });
     } else {
-      console.error(`Professor ${broncoDirectName} not found.`);
+      console.error(
+        `Professor ${broncoDirectName} not found in GraphQL query.`
+      );
     }
   } catch (err) {
     console.error(err);
@@ -150,7 +152,7 @@ async function updateProf({
  * Value can be extracted by awaiting function call within an async function
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function profSearch(broncoDirectName: string): Promise<Professor> {
+export async function profSearch(broncoDirectName: string): Promise<Professor> {
   const result = await execute(
     'SELECT * FROM `rateMyProfessorDB` WHERE `profName` = ?',
     [broncoDirectName]
@@ -319,6 +321,6 @@ export async function initializeMySQL(): Promise<void> {
   // await addProf(sampleProfArray[0]);
   // const result = await profSearch('Thanh Nguyen');
   // console.log(result);
-  const result = await profSearch('Ben Steichen');
-  console.log(result);
+  // const result = await profSearch('Ben Steichen');
+  // console.log(result);
 }

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -103,6 +103,9 @@ async function addProfGraphQL({
           legacyId.toString(),
         ]
       );
+      console.log(
+        `[SUCCESS] Professor ${profName} has been added to the database.`
+      );
     } else {
       console.error(`Professor ${profName} already exists in the database.`);
     }
@@ -139,6 +142,7 @@ export async function updateProf({
         profName,
       ]
     );
+    console.log(`[SUCCESS] Professor ${profName} has been updated.`);
   } catch (err) {
     console.error(err);
   }
@@ -176,9 +180,11 @@ export async function profSearch(broncoDirectName: string): Promise<Professor> {
     'SELECT * FROM `rateMyProfessorDB` WHERE `profName` = ?',
     [broncoDirectName]
   );
-  result.avgDifficulty = parseFloat(result.avgDifficulty);
-  result.avgRating = parseFloat(result.avgRating);
-  result.wouldTakeAgainPercent = parseFloat(result.wouldTakeAgainPercent);
+  if (result) {
+    result.avgDifficulty = parseFloat(result.avgDifficulty);
+    result.avgRating = parseFloat(result.avgRating);
+    result.wouldTakeAgainPercent = parseFloat(result.wouldTakeAgainPercent);
+  }
   return result;
 }
 

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -171,7 +171,7 @@ export async function checkExpiredProfData(
  * Value can be extracted by awaiting function call within an async function
  */
 export async function profSearch(broncoDirectName: string): Promise<Professor> {
-  const result = await execute(
+  const [result] = await execute(
     'SELECT * FROM `rateMyProfessorDB` WHERE `profName` = ?',
     [broncoDirectName]
   );

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -176,6 +176,9 @@ export async function profSearch(broncoDirectName: string): Promise<Professor> {
     'SELECT * FROM `rateMyProfessorDB` WHERE `profName` = ?',
     [broncoDirectName]
   );
+  result.avgDifficulty = parseFloat(result.avgDifficulty);
+  result.avgRating = parseFloat(result.avgRating);
+  result.wouldTakeAgainPercent = parseFloat(result.wouldTakeAgainPercent);
   return result;
 }
 

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -319,9 +319,9 @@ export async function initializeMySQL(): Promise<void> {
         console.log(`Added ${val.firstName + ' ' + val.lastName} - `, index);
       })
     );
-  } else {
-    console.log(`professorDB is already populated.`);
   }
+
+  console.log('MySQL server successfully started!');
 
   // const sampleProf: Professor = {
   //   profName: 'Poppy Gloria',

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -29,6 +29,39 @@ async function execute(cmd: string, placeholder?: string[]): Promise<any> {
 }
 
 /**
+ * Updates existing professor data in the SQL database
+ * @param {Professor} newProfessor See professor interface (/api/Professor.d.ts)
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function updateProf({
+  profName,
+  avgDifficulty,
+  avgRating,
+  numRatings,
+  wouldTakeAgainPercent,
+}: Professor): Promise<void> {
+  try {
+    void execute(
+      `UPDATE professorDB SET
+              avgDifficulty = ?,
+              avgRating = ?,
+              numRatings = ?,
+              wouldTakeAgainPercent = ?,
+              WHERE profName = ?`,
+      [
+        avgDifficulty.toFixed(1),
+        avgRating.toFixed(1),
+        numRatings.toString(),
+        wouldTakeAgainPercent.toFixed(2),
+        profName,
+      ]
+    );
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+/**
  * Finds a professor in the SQL Database given their BroncoDirect name.
  * @param {string}  broncoDirectName BroncoDirect name
  * @return {Promise<void>} Array of JSON values.
@@ -43,8 +76,10 @@ async function profSearch(broncoDirectName: string): Promise<void> {
   return result;
 }
 
+/* --- professorDB FUNCTIONS --- */
+
 /**
- * Adds a professor to the profDB table in SQL database
+ * Adds a professor to the professorDB table in SQL database
  * @param {string} broncoDirectName name to be added
  */
 export function addProfName(broncoDirectName: string): void {
@@ -54,7 +89,7 @@ export function addProfName(broncoDirectName: string): void {
 }
 
 /**
- * Checks if a professor exists in the database (meaning they are a valid professor)
+ * Checks if a professor's name exists in the `professorDB` database (meaning they are a valid professor)
  * @param {string} broncoDirectName name to be checked
  * @return {Promise<object[]>} Array of JSON values
  */
@@ -68,44 +103,14 @@ export async function checkProfName(
   return result;
 }
 
-/**
- * Updates existing professor in the SQL database
- * @param {Professor} newProfessor See professor interface (/api/Professor.d.ts)
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function updateProf({
-  broncoDirectName,
-  rmpName,
-  rmpURL,
-  profRating,
-  profDifficulty,
-  takeClassAgain,
-}: Professor): Promise<void> {
-  void execute(
-    `UPDATE professorDB SET
-  rmpName = ?,
-  rmpURL = ?,
-  profRating = ?,
-  profDifficulty = ?,
-  takeClassAgain = ?
-  WHERE broncoDirectName = ?`,
-    [
-      rmpName,
-      rmpURL,
-      profRating.toFixed(2),
-      profDifficulty.toFixed(2),
-      takeClassAgain.toFixed(2),
-      broncoDirectName,
-    ]
-  );
-}
-
 // used to populate professorDB if doesn't already exist
 async function checkDatabaseExist(): Promise<boolean> {
   const result = await execute(`SELECT COUNT(*) FROM professorDB`);
   const resultAmount = Object.values(result[0])[0] as number;
   return resultAmount > 0;
 }
+
+/* --- MySQL FUNCTIONS --- */
 
 // checks if there is an active SQL connection
 export async function checkSQLConnection(): Promise<boolean> {

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -163,10 +163,7 @@ export async function checkExpiredProfData(
     'SELECT * FROM `rateMyProfessorDB` WHERE `profName` = ? AND TIMESTAMPDIFF(SECOND, `timeAdded`, NOW()) >= 7884000',
     [name]
   );
-  if (Object.keys(result).length === 0) {
-    return false;
-  }
-  return true;
+  return Object.keys(result).length !== 0;
 }
 
 /**

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -176,14 +176,19 @@ export async function initializeMySQL(): Promise<void> {
   void execute(`
     CREATE TABLE IF NOT EXISTS rateMyProfessorDB (
       profID int NOT NULL PRIMARY KEY AUTO_INCREMENT,
-      broncoDirectName varchar(255),
-      rmpName varchar(255),
-      rmpURL LONGTEXT,
-      profRating varchar(255),
-      profDifficulty varchar(255),
-      takeClassAgain varchar(255)
+      profName varchar(255),
+      firstName varchar(255),
+      lastName varchar(255),
+      avgDifficulty float(2, 1),
+      avgRating float(2, 1),
+      numRatings int,
+      wouldTakeAgainPercent float(7, 4),
+      timeAdded timestamp DEFAULT CURRENT_TIMESTAMP,
+      id varchar(255),
+      legacyId int
     )
   `);
+
   void execute(`CREATE TABLE IF NOT EXISTS professorDB (
     profID int NOT NULL PRIMARY KEY AUTO_INCREMENT,
     broncoDirectName varchar(255)

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -79,7 +79,7 @@ async function addProfGraphQL({
   try {
     // Check if data already exists in db
     const result = await profSearch(profName);
-    if (result && Object.keys(result).length === 0) {
+    if (!result || Object.keys(result).length === 0) {
       void execute(
         `INSERT INTO rateMyProfessorDB (
         profName, 

--- a/api/sql.ts
+++ b/api/sql.ts
@@ -9,7 +9,7 @@ let connection: any;
 /**
  * Internal use function to execute a single SQL command as prepared statements with error catching.
  * @param {string} SQLCommand Single quotation marks for one-line commands. Template string for multi-line commands.
- * @param {string[]} [placeholder] Optional parameter used for SQL commands that require function parameters
+ * @param {string[]} [placeholder] Optional parameter used for SQL commands that require function parameters.
  */
 async function execute(cmd: string, placeholder?: string[]): Promise<any> {
   const data = await new Promise((resolve) =>
@@ -29,9 +29,11 @@ async function execute(cmd: string, placeholder?: string[]): Promise<any> {
   return data;
 }
 
+/* --- rateMyProfessorDB FUNCTIONS --- */
+
 /**
- * Adds a new professor entry into `rateMyProfessorDB` using a professor's full name
- * @param {Professor} newProfessor See professor interface (/api/Professor.d.ts)
+ * Adds a new professor entry into `rateMyProfessorDB` using a professor's full name.
+ * @param {Professor} newProfessor See professor interface (/api/Professor.d.ts).
  */
 export async function addProf(broncoDirectName: string): Promise<void> {
   try {
@@ -59,10 +61,10 @@ export async function addProf(broncoDirectName: string): Promise<void> {
 }
 
 /**
- * Private function - use `addProf(broncoDirectName)` to query data
+ * Private function - use `addProf(broncoDirectName)` to query data.
  *
- * Adds a new professor entry into `rateMyProfessorDB` using data from GraphQL
- * @param {Professor} newProfessor See professor interface (/api/Professor.d.ts)
+ * Adds a new professor entry into `rateMyProfessorDB` using data from GraphQL.
+ * @param {Professor} newProfessor See professor interface (/api/Professor.d.ts).
  */
 async function addProfGraphQL({
   profName,
@@ -78,7 +80,7 @@ async function addProfGraphQL({
   try {
     // Check if data already exists in db
     const result = await profSearch(profName);
-    if (Object.keys(result).length === 0) {
+    if (result && Object.keys(result).length === 0) {
       void execute(
         `INSERT INTO rateMyProfessorDB (
         profName, 
@@ -111,8 +113,8 @@ async function addProfGraphQL({
 }
 
 /**
- * Updates existing professor data in the SQL database
- * @param {Professor} newProfessor See professor interface (/api/Professor.d.ts)
+ * Updates existing professor data in the SQL database.
+ * @param {Professor} newProfessor See professor interface (/api/Professor.d.ts).
  */
 export async function updateProf({
   profName,
@@ -168,7 +170,7 @@ export async function checkExpiredProfData(
  * Finds a professor in the SQL Database given their BroncoDirect name.
  * @param {string}  broncoDirectName BroncoDirect name.
  * @return {Promise<Professor>} JSON of professor data.
- * Value can be extracted by awaiting function call within an async function
+ * Value can be extracted by awaiting function call within an async function.
  */
 export async function profSearch(broncoDirectName: string): Promise<Professor> {
   const [result] = await execute(
@@ -181,8 +183,8 @@ export async function profSearch(broncoDirectName: string): Promise<Professor> {
 /* --- professorDB FUNCTIONS --- */
 
 /**
- * Adds a professor to the professorDB table in SQL database
- * @param {string} broncoDirectName name to be added
+ * Adds a professor to the professorDB table in SQL database.
+ * @param {string} broncoDirectName name to be added.
  */
 export function addProfName(broncoDirectName: string): void {
   void execute('INSERT INTO professorDB (broncoDirectName) VALUES (?)', [
@@ -191,9 +193,9 @@ export function addProfName(broncoDirectName: string): void {
 }
 
 /**
- * Checks if a professor's name exists in the `professorDB` database (meaning they are a valid professor)
- * @param {string} broncoDirectName name to be checked
- * @return {Promise<object[]>} Array of JSON values
+ * Checks if a professor's name exists in the `professorDB` database (meaning they are a valid professor).
+ * @param {string} broncoDirectName name to be checked.
+ * @return {Promise<object[]>} Array of JSON values.
  */
 export async function checkProfName(
   broncoDirectName: string
@@ -205,7 +207,10 @@ export async function checkProfName(
   return result;
 }
 
-// used to populate professorDB if doesn't already exist
+/**
+ * Checks if `professorDB` already has prof names in it.
+ * @return {Promise<boolean>} True if db has data in it, false otherwise.
+ */
 async function checkDatabaseExist(): Promise<boolean> {
   const result = await execute(`SELECT COUNT(*) FROM professorDB`);
   const resultAmount = Object.values(result[0])[0] as number;
@@ -331,10 +336,10 @@ export async function initializeMySQL(): Promise<void> {
   // ];
 
   // console.log('\n[BRONCODIRECT] Testing Professor Functions.\n-----\n');
-  // // console.log('[BRONCODIRECT] Add Poppy Gloria to table');
-  // // await addProfGraphQL(sampleProf);
-  // // const result = await profSearch('Poppy Gloria');
-  // // console.log(result);
+  // console.log('[BRONCODIRECT] Add Poppy Gloria to table');
+  // await addProfGraphQL(sampleProf);
+  // const result = await profSearch('Poppy Gloria');
+  // console.log(result);
 
   // await addProf(sampleProfArray[0]);
   // const result = await profSearch('Thanh Nguyen');

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.0.2",
         "express": "^4.18.1",
+        "graphql": "^16.6.0",
         "graphql-request": "^5.0.0",
         "mysql2": "^2.3.3",
         "ts-node": "^10.9.1",
@@ -2232,7 +2233,6 @@
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -6255,8 +6255,7 @@
     "graphql": {
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-      "peer": true
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
     },
     "graphql-request": {
       "version": "5.0.0",

--- a/scraper/graphql/interface.ts
+++ b/scraper/graphql/interface.ts
@@ -12,6 +12,7 @@ export interface ProfessorPage {
   avgDifficulty: number;
   avgRating: number;
   numRatings: number;
+  wouldTakeAgainPercent: number;
   legacyId: number;
   id: number;
 }

--- a/scraper/graphql/interface.ts
+++ b/scraper/graphql/interface.ts
@@ -14,5 +14,5 @@ export interface ProfessorPage {
   numRatings: number;
   wouldTakeAgainPercent: number;
   legacyId: number;
-  id: number;
+  id: string;
 }

--- a/scraper/scraper.ts
+++ b/scraper/scraper.ts
@@ -69,6 +69,11 @@ export const getProfessorByName = async (
     // returns promise object of the professors data
     const professor = await getProfessorData(professorId);
     return professor;
+  } else if (getProfessorResults.length > 1) {
+    /* NOTE: Querying professors may result in multiple of the same one - We handle this by taking the 1st professor data rather than all */
+    /* This is a TEMPORARY SOLUTION -- in the future, we should handle this by creating several different rating components */
+    const professor = await getProfessorData(getProfessorResults[0].id);
+    return professor;
   }
   return null;
 };


### PR DESCRIPTION
Previously, our backend directly queried data from GraphQL then stored it into a hashmap, which sort of acted as a lite caching method to handling professor data so that we don't constantly query GraphQL (and piss off RMP). The flaw with this is if the backend server ever restarts, the hashmap's data is flushed. 

These changes aims to fix that by storing all data in a MySQL database and grab data from there rather than solely the server. This should speed up the process of grabbing data significantly. Additionally, the professor's data is automatically re-queried if their data has exceeded 3 months since the last time their data was changed (i.e., first queried).

Furthermore, I changed the db table that handles professor names to use RateMyProfessors names instead of scraped names, which should guarantee all professors that actually have any ratings at all (this doesn't guarantee all professors will be able to be seen via the extension, but that would also mean they don't have any ratings).

**A big issue to consider is dealing with professors that have duplicate entries in RateMyProfessors.** Our current fix to that is to take the 1st entry and display that as data, but this can be very misleading (i.e., low review count/inflated rating). It works now though, so it's whatever.